### PR TITLE
Add assert to systeminfo_test

### DIFF
--- a/internal/systeminfo/systeminfo_test.go
+++ b/internal/systeminfo/systeminfo_test.go
@@ -257,6 +257,7 @@ func Test_SystemInfo_GetLogFile_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Log(err.Error())
 	}
+	assert.NoError(t, err)
 }
 
 func Test_SystemInfo_GetLogFile_ErrorOnZip(t *testing.T) {
@@ -283,6 +284,7 @@ func Test_SystemInfo_GetLogFile_ErrorOnZip(t *testing.T) {
 	if err != nil {
 		t.Log(err.Error())
 	}
+	assert.Error(t, err)
 }
 
 func Test_SystemInfo_GetLogFile_ErrorOnCatDeviceName(t *testing.T) {
@@ -309,6 +311,7 @@ func Test_SystemInfo_GetLogFile_ErrorOnCatDeviceName(t *testing.T) {
 	if err != nil {
 		t.Log(err.Error())
 	}
+	assert.NoError(t, err)
 }
 
 func Test_SystemInfo_GetLogFile_ErrorOnPathCheck(t *testing.T) {
@@ -323,6 +326,7 @@ func Test_SystemInfo_GetLogFile_ErrorOnPathCheck(t *testing.T) {
 	if err != nil {
 		t.Log(err.Error())
 	}
+	assert.Error(t, err)
 }
 
 func Test_SystemInfo_GetLogFile_ErrorOnJournalctl(t *testing.T) {
@@ -340,6 +344,7 @@ func Test_SystemInfo_GetLogFile_ErrorOnJournalctl(t *testing.T) {
 	if err != nil {
 		t.Log(err.Error())
 	}
+	assert.Error(t, err)
 }
 
 func Test_SystemInfo_GetLogFile_ErrorOnDeviceNameFileCheck(t *testing.T) {
@@ -366,6 +371,7 @@ func Test_SystemInfo_GetLogFile_ErrorOnDeviceNameFileCheck(t *testing.T) {
 	if err != nil {
 		t.Log(err.Error())
 	}
+	assert.NoError(t, err)
 }
 
 func Test_SystemInfo_GetLogFile_ErrorOnDeviceNameFileCheckAndHostname(t *testing.T) {
@@ -392,4 +398,5 @@ func Test_SystemInfo_GetLogFile_ErrorOnDeviceNameFileCheckAndHostname(t *testing
 	if err != nil {
 		t.Log(err.Error())
 	}
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Previous log tests will pass anyway without assert (always happy path).

However, this depends on whether `ErrorOnCatDeviceName` `ErrorOnDeviceNameFileCheck` and `ErrorOnDeviceNameFileCheckAndHostname` should return no error when the `uniqIdentifierForLogFile` can't be decided.

I assume the `GetLogFile` is **expected** to progress with no error even those cases occur and `uniqIdentifierForLogFile` will be empty (current behaviour). Otherwise, `assert.Error` instead and the case should fail before it's fixed.